### PR TITLE
[7.0] Support full payload for concrete resolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.5.0",
+        "phpunit/phpunit": "^10",
         "illuminate/container": "^10.0"
     },
     "autoload": {

--- a/src/Annotation/ConcreteResolver.php
+++ b/src/Annotation/ConcreteResolver.php
@@ -14,11 +14,11 @@ abstract class ConcreteResolver
     protected array $concretes = [];
 
     /**
-     * @param array $data
-     *
+     * @param  array  $data
+     * @param  array  $all
      * @return string|null
      */
-    abstract public function concreteFor(array $data): ?string;
+    abstract public function concreteFor(array $data, array $all): ?string;
 
     /**
      * @return array

--- a/src/Annotation/ConcreteResolver.php
+++ b/src/Annotation/ConcreteResolver.php
@@ -14,8 +14,9 @@ abstract class ConcreteResolver
     protected array $concretes = [];
 
     /**
-     * @param  array  $data
-     * @param  array  $all
+     * @param array $data
+     * @param array $all
+     *
      * @return string|null
      */
     abstract public function concreteFor(array $data, array $all): ?string;

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -23,7 +23,6 @@ use SergiX44\Hydrator\Annotation\OverrideConstructor;
 use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Hydrator\Annotation\UnionResolver;
 use SergiX44\Hydrator\Exception\InvalidObjectException;
-
 use function array_key_exists;
 use function class_exists;
 use function ctype_digit;
@@ -39,7 +38,6 @@ use function is_string;
 use function is_subclass_of;
 use function sprintf;
 use function strtotime;
-
 use const FILTER_NULL_ON_FAILURE;
 use const FILTER_VALIDATE_BOOLEAN;
 use const FILTER_VALIDATE_FLOAT;
@@ -85,8 +83,8 @@ class Hydrator implements HydratorInterface
         }
 
         $object = $this->initializeObject($object, $data, $additional);
-
         $class = new ReflectionClass($object);
+        $keys = [];
         foreach ($class->getProperties() as $property) {
             // statical properties cannot be hydrated...
             if ($property->isStatic()) {
@@ -149,13 +147,15 @@ class Hydrator implements HydratorInterface
             }
 
             $this->hydrateProperty($object, $class, $property, $propertyType, $data[$key], $data);
-            unset($data[$key]);
+            $keys[] = $key;
         }
+
+        $data = array_diff_key($data, array_flip($keys));
 
         // if the object has a __set method, we will use it to hydrate the remaining data
         if (!empty($data) && $class->hasMethod('__set')) {
             foreach ($data as $key => $value) {
-                $object->$key = $value;
+                $object->__set($key, $value);
             }
         }
 

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -23,6 +23,7 @@ use SergiX44\Hydrator\Annotation\OverrideConstructor;
 use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Hydrator\Annotation\UnionResolver;
 use SergiX44\Hydrator\Exception\InvalidObjectException;
+
 use function array_key_exists;
 use function class_exists;
 use function ctype_digit;
@@ -38,6 +39,7 @@ use function is_string;
 use function is_subclass_of;
 use function sprintf;
 use function strtotime;
+
 use const FILTER_NULL_ON_FAILURE;
 use const FILTER_VALIDATE_BOOLEAN;
 use const FILTER_VALIDATE_FLOAT;

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -23,6 +23,7 @@ use SergiX44\Hydrator\Annotation\OverrideConstructor;
 use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Hydrator\Annotation\UnionResolver;
 use SergiX44\Hydrator\Exception\InvalidObjectException;
+
 use function array_key_exists;
 use function class_exists;
 use function ctype_digit;
@@ -38,6 +39,7 @@ use function is_string;
 use function is_subclass_of;
 use function sprintf;
 use function strtotime;
+
 use const FILTER_NULL_ON_FAILURE;
 use const FILTER_VALIDATE_BOOLEAN;
 use const FILTER_VALIDATE_FLOAT;
@@ -57,7 +59,7 @@ class Hydrator implements HydratorInterface
      *
      * @param class-string<T>|T $object
      * @param array|object      $data
-     * @param array            $additional
+     * @param array             $additional
      *
      * @throws Exception\UnsupportedPropertyTypeException
      *                                                    If one of the object properties contains an unsupported type.
@@ -215,7 +217,7 @@ class Hydrator implements HydratorInterface
      *
      * @param class-string<T>|T $object
      * @param array|object      $data
-     * @param array            $additional
+     * @param array             $additional
      *
      * @throws ContainerExceptionInterface
      *                                     If the object cannot be initialized.

--- a/tests/Fixtures/ObjectWithAbstract.php
+++ b/tests/Fixtures/ObjectWithAbstract.php
@@ -7,4 +7,5 @@ use SergiX44\Hydrator\Tests\Fixtures\Store\Apple;
 final class ObjectWithAbstract
 {
     public Apple $value;
+    public string $name = 'Apple';
 }

--- a/tests/Fixtures/Resolver/AppleResolver.php
+++ b/tests/Fixtures/Resolver/AppleResolver.php
@@ -15,7 +15,7 @@ class AppleResolver extends ConcreteResolver
         'sauce' => AppleSauce::class,
     ];
 
-    public function concreteFor(array $data): ?string
+    public function concreteFor(array $data, array $all): ?string
     {
         return $this->concretes[$data['type']] ?? null;
     }

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -834,7 +834,7 @@ class HydratorTest extends TestCase
     public function testHydrateAbstractPropertyWithAdditional(): void
     {
         $o = (new Hydrator())->hydrate(new ObjectWithAbstract(), [
-            'name' => 'notApple',
+            'name'  => 'notApple',
             'value' => [
                 'type'      => 'jack',
                 'sweetness' => null,

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -846,6 +846,7 @@ class HydratorTest extends TestCase
         $this->assertInstanceOf(AppleJack::class, $o->value);
         $this->assertSame('jack', $o->value->type);
         $this->assertSame('brandy', $o->value->category);
+        $this->assertSame('notApple', $o->name);
     }
 
     public function testHydrateArrayAbstractProperty(): void

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -831,6 +831,23 @@ class HydratorTest extends TestCase
         $this->assertSame('brandy', $o->value->category);
     }
 
+    public function testHydrateAbstractPropertyWithAdditional(): void
+    {
+        $o = (new Hydrator())->hydrate(new ObjectWithAbstract(), [
+            'name' => 'notApple',
+            'value' => [
+                'type'      => 'jack',
+                'sweetness' => null,
+                'category'  => 'brandy',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ObjectWithAbstract::class, $o);
+        $this->assertInstanceOf(AppleJack::class, $o->value);
+        $this->assertSame('jack', $o->value->type);
+        $this->assertSame('brandy', $o->value->category);
+    }
+
     public function testHydrateArrayAbstractProperty(): void
     {
         $o = (new Hydrator())->hydrate(new ObjectWithArrayOfAbstracts(), [


### PR DESCRIPTION
This pull request introduces updates to the `Hydrator` class and related components to support additional contextual data during object hydration. It also updates dependencies and adds new test coverage for the changes. The most significant changes include modifications to method signatures, enhancements to the hydration process, and updates to the test suite.

### Updates to Dependencies:
* Updated `phpunit/phpunit` in `composer.json` to version `^10` for compatibility with the latest PHPUnit features.

### Enhancements to Hydration Process:
* Added an `array $additional` parameter to multiple methods in the `Hydrator` class, including `hydrate`, `initializeObject`, `hydrateProperty`, and others, to allow passing additional contextual data during hydration. [[1]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L80-R87) [[2]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L227-R230) [[3]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L339-R343)
* Updated the `hydrateObjectsInArray` method to propagate the `additional` parameter when recursively hydrating nested objects.
* Enhanced the `propertyFromInstance` and `propertyArray` methods to utilize the `additional` parameter during object hydration. [[1]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L841-R847) [[2]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L596-R601)

### Changes to Abstract Resolvers:
* Modified the `concreteFor` method in the `ConcreteResolver` abstract class to accept an additional `array $all` parameter, enabling more contextual decision-making when resolving concrete implementations. [[1]](diffhunk://#diff-67ac4831d2bb4583d6a1febb9e3ba81a8b8cd16efb6af9c7c4053e247194249aR18-R22) [[2]](diffhunk://#diff-280c03a425894647dfd873da98bd9514a60d79ccb4a6680087f7e9c351d8cef9L18-R18)

### Test Suite Enhancements:
* Added a new test, `testHydrateAbstractPropertyWithAdditional`, to validate the behavior of the `Hydrator` class when using the `additional` parameter during object hydration.
* Updated the `ObjectWithAbstract` fixture to include a new `name` property for testing purposes.