### PR TITLE
Support PHP 8.5

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,14 @@
 <?xml version="1.0"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage>
-        <include>
-            <directory>./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
     <testsuites>
         <testsuite name="SergiX44/hydrator">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Annotation/ConcreteResolver.php
+++ b/src/Annotation/ConcreteResolver.php
@@ -3,13 +3,14 @@
 namespace SergiX44\Hydrator\Annotation;
 
 use Attribute;
+use RuntimeException;
 
 /**
  * @Annotation
  * @Target({"CLASS"})
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-abstract class ConcreteResolver
+class ConcreteResolver
 {
     protected array $concretes = [];
 
@@ -19,7 +20,10 @@ abstract class ConcreteResolver
      *
      * @return string|null
      */
-    abstract public function concreteFor(array $data, array $all): ?string;
+    public function concreteFor(array $data, array $all): ?string
+    {
+        throw new RuntimeException('This class is meant to be extended to provide your own ConcreteResolver logic.');
+    }
 
     /**
      * @return array

--- a/src/Annotation/UnionResolver.php
+++ b/src/Annotation/UnionResolver.php
@@ -6,13 +6,14 @@ use Attribute;
 use ReflectionException;
 use ReflectionNamedType;
 use ReflectionType;
+use RuntimeException;
 
 /**
  * @Annotation
  * @Target({"PROPERTY"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-abstract class UnionResolver
+class UnionResolver
 {
     /**
      * @param string                $propertyName
@@ -23,5 +24,8 @@ abstract class UnionResolver
      *
      * @return ReflectionType
      */
-    abstract public function resolve(string $propertyName, array $propertyTypes, array $data): ReflectionType;
+    public function resolve(string $propertyName, array $propertyTypes, array $data): ReflectionType
+    {
+        throw new RuntimeException('This class is meant to be extended to provide your own UnionResolver logic.');
+    }
 }

--- a/src/Exception/InvalidValueException.php
+++ b/src/Exception/InvalidValueException.php
@@ -4,6 +4,7 @@ namespace SergiX44\Hydrator\Exception;
 
 use ReflectionProperty;
 use Throwable;
+
 use function sprintf;
 
 class InvalidValueException extends HydrationException

--- a/src/Exception/InvalidValueException.php
+++ b/src/Exception/InvalidValueException.php
@@ -4,7 +4,6 @@ namespace SergiX44\Hydrator\Exception;
 
 use ReflectionProperty;
 use Throwable;
-
 use function sprintf;
 
 class InvalidValueException extends HydrationException
@@ -32,7 +31,6 @@ class InvalidValueException extends HydrationException
     ) {
         parent::__construct($message, $code, $previous);
 
-        $property->setAccessible(false);
         $this->property = $property;
     }
 

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -246,7 +246,7 @@ class HydratorTest extends TestCase
         $this->assertSame($expected, $object->value);
     }
 
-    public function booleanValueProvider(): array
+    public static function booleanValueProvider(): array
     {
         return [
             [true, true],
@@ -280,7 +280,7 @@ class HydratorTest extends TestCase
         $this->assertSame($expected, $object->value);
     }
 
-    public function integerValueProvider(): array
+    public static function integerValueProvider(): array
     {
         return [
             [42, 42],
@@ -306,7 +306,7 @@ class HydratorTest extends TestCase
         $this->assertSame($expected, $object->value);
     }
 
-    public function numberValueProvider(): array
+    public static function numberValueProvider(): array
     {
         return [
             [42, 42.0],
@@ -438,7 +438,7 @@ class HydratorTest extends TestCase
         $this->assertSame($expected, $object->value->format('Y-m-d'));
     }
 
-    public function timestampValueProvider(): array
+    public static function timestampValueProvider(): array
     {
         return [
             [1262304000, '2010-01-01'],
@@ -577,7 +577,7 @@ class HydratorTest extends TestCase
         $this->assertSame($expected, $object->value);
     }
 
-    public function stringableEnumValueProvider(): array
+    public static function stringableEnumValueProvider(): array
     {
         return [
             ['c1200a7e-136e-4a11-9bc3-cc937046e90f', Fixtures\StringableEnum::foo],
@@ -615,7 +615,7 @@ class HydratorTest extends TestCase
         $this->assertSame($expected, $object->value);
     }
 
-    public function numerableEnumValueProvider(): array
+    public static function numerableEnumValueProvider(): array
     {
         return [
             [1, Fixtures\NumerableEnum::foo],


### PR DESCRIPTION
This pull request updates the codebase to improve compatibility with newer versions of PHPUnit and refines the design of annotation resolver classes. The most important changes include upgrading the PHPUnit configuration file, converting abstract resolver classes to concrete classes with explicit error handling, and making test data providers static for better PHPUnit compatibility.

**PHPUnit upgrade and test improvements:**

* Upgraded the PHPUnit configuration in `phpunit.xml.dist` to use the version 10.5 schema, and updated coverage configuration to the new `<source>` format.
* Changed all test data provider methods in `tests/HydratorTest.php` to be static, ensuring compatibility with PHPUnit 10. [[1]](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45L249-R249) [[2]](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45L283-R283) [[3]](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45L309-R309) [[4]](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45L441-R441) [[5]](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45L580-R580) [[6]](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45L618-R618)

**Annotation resolver class refactoring:**

* Converted `ConcreteResolver` and `UnionResolver` from abstract classes to concrete classes, and updated their key methods to throw a `RuntimeException` if called directly, clarifying that these classes are intended to be extended. [[1]](diffhunk://#diff-67ac4831d2bb4583d6a1febb9e3ba81a8b8cd16efb6af9c7c4053e247194249aR6-R13) [[2]](diffhunk://#diff-67ac4831d2bb4583d6a1febb9e3ba81a8b8cd16efb6af9c7c4053e247194249aL22-R26) [[3]](diffhunk://#diff-3f4548a8796de4f1e4b42444f26f88d02cf44f54c1abfd71254398b40341f41fR9-R16) [[4]](diffhunk://#diff-3f4548a8796de4f1e4b42444f26f88d02cf44f54c1abfd71254398b40341f41fL26-R30)

**Minor codebase cleanup:**

* Removed a redundant call to `setAccessible(false)` in the constructor of `InvalidValueException.php`.