### PR TITLE
Add skipScalars option to ArrayType for value hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,26 @@ public array $value;
 ],
 ```
 
+By default, every element of the array is hydrated into the given class, so a
+scalar element (or `null`) will raise an error. Set `skipScalars: true` to leave
+scalar and `null` elements untouched, hydrating only the array/object elements:
+
+```php
+#[ArrayType(SomeDto::class, skipScalars: true)]
+public array $value;
+```
+
+```php
+[
+    'value' => [
+        ['value' => 'foo'], // hydrated into SomeDto
+        'bar',              // kept as-is
+        42,                 // kept as-is
+        null,               // kept as-is
+    ],
+],
+```
+
 ## Object
 
 Accepts only objects.

--- a/src/Annotation/ArrayType.php
+++ b/src/Annotation/ArrayType.php
@@ -20,13 +20,22 @@ final class ArrayType
     public int $depth;
 
     /**
+     * When true, scalar (and null) array elements are passed through as-is
+     * instead of being hydrated into the target class.
+     *
+     * @var bool
+     */
+    public bool $skipScalars;
+
+    /**
      * Constructor of the class.
      *
      * @param class-string $class
      */
-    public function __construct(string $class, int $depth = 1)
+    public function __construct(string $class, int $depth = 1, bool $skipScalars = false)
     {
         $this->class = $class;
         $this->depth = $depth;
+        $this->skipScalars = $skipScalars;
     }
 }

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -36,6 +36,7 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_object;
+use function is_scalar;
 use function is_string;
 use function is_subclass_of;
 use function sprintf;
@@ -619,7 +620,13 @@ class Hydrator implements HydratorInterface
 
         $arrayType = $this->getAttributeInstance($property, ArrayType::class);
         if ($arrayType !== null) {
-            $value = $this->hydrateObjectsInArray($value, $arrayType->class, $arrayType->depth, $additional);
+            $value = $this->hydrateObjectsInArray(
+                $value,
+                $arrayType->class,
+                $arrayType->depth,
+                $arrayType->skipScalars,
+                $additional
+            );
         }
 
         $property->setValue($object, $value);
@@ -629,22 +636,36 @@ class Hydrator implements HydratorInterface
      * @param array  $array
      * @param string $class
      * @param int    $depth
+     * @param bool   $skipScalars
      *
      * @throws \ReflectionException
      *
      * @return array
      */
-    private function hydrateObjectsInArray(array $array, string $class, int $depth, array $additional = []): array
-    {
+    private function hydrateObjectsInArray(
+        array $array,
+        string $class,
+        int $depth,
+        bool $skipScalars = false,
+        array $additional = []
+    ): array {
         if ($depth > 1) {
-            return array_map(function ($child) use ($class, $depth, $additional) {
-                return $this->hydrateObjectsInArray($child, $class, --$depth, $additional);
+            return array_map(function ($child) use ($class, $depth, $skipScalars, $additional) {
+                if ($skipScalars && (is_scalar($child) || $child === null)) {
+                    return $child;
+                }
+
+                return $this->hydrateObjectsInArray($child, $class, --$depth, $skipScalars, $additional);
             }, $array);
         }
 
-        return array_map(function ($object) use ($class, $additional) {
+        return array_map(function ($object) use ($class, $skipScalars, $additional) {
             if (is_subclass_of($class, BackedEnum::class)) {
                 return $class::tryFrom($object) ?? $object;
+            }
+
+            if ($skipScalars && (is_scalar($object) || $object === null)) {
+                return $object;
             }
 
             return $this->hydrate($class, $object, $additional);

--- a/tests/Fixtures/ObjectWithTypedArraySkippingScalars.php
+++ b/tests/Fixtures/ObjectWithTypedArraySkippingScalars.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SergiX44\Hydrator\Tests\Fixtures;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Tests\Fixtures\Store\Tag;
+
+final class ObjectWithTypedArraySkippingScalars
+{
+    #[ArrayType(Tag::class, skipScalars: true)]
+    public array $value;
+}

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -396,6 +396,41 @@ class HydratorTest extends TestCase
         $this->assertSame('fif', $object->value[1][1]->name);
     }
 
+    public function testHydrateTypedArrayablePropertySkippingScalars(): void
+    {
+        $object = (new Hydrator())->hydrate(Fixtures\ObjectWithTypedArraySkippingScalars::class, [
+            'value' => [
+                ['name' => 'foo'],
+                'bar',
+                42,
+                3.14,
+                true,
+                null,
+            ],
+        ]);
+
+        $this->assertIsArray($object->value);
+        $this->assertInstanceOf(Tag::class, $object->value[0]);
+        $this->assertSame('foo', $object->value[0]->name);
+        $this->assertSame('bar', $object->value[1]);
+        $this->assertSame(42, $object->value[2]);
+        $this->assertSame(3.14, $object->value[3]);
+        $this->assertTrue($object->value[4]);
+        $this->assertNull($object->value[5]);
+    }
+
+    public function testHydrateTypedArrayablePropertyWithoutSkippingScalarsFailsOnScalar(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        (new Hydrator())->hydrate(Fixtures\ObjectWithTypedArray::class, [
+            'value' => [
+                ['name' => 'foo'],
+                'bar',
+            ],
+        ]);
+    }
+
     public function testHydrateArrayablePropertyWithInvalidValue(): void
     {
         $this->expectException(Exception\InvalidValueException::class);


### PR DESCRIPTION
This pull request introduces a new `skipScalars` option to the `ArrayType` annotation, allowing you to control whether scalar and `null` values in typed arrays are hydrated or left as-is. This provides greater flexibility when handling arrays that may contain a mix of objects and scalar values. The changes also include comprehensive tests and documentation updates.

**New Feature: ArrayType `skipScalars` option**
- [`src/Annotation/ArrayType.php`](diffhunk://#diff-6de988ab2343dcb803c03d4a54a570736f2d8bd879246ab3ed52153a4dc82e77R22-R39): Added the `skipScalars` boolean property to the `ArrayType` annotation, and updated the constructor to accept this new parameter. When set to `true`, scalar and `null` values in arrays are not hydrated into objects.
- [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R166-R185): Updated documentation to explain the new `skipScalars` option, including usage examples and expected behavior.

**Hydration Logic Updates**
- [`src/Hydrator.php`](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L622-R629): Updated the `hydrateObjectsInArray` method and its callers to support the `skipScalars` parameter, ensuring scalar and `null` elements are passed through unchanged when the option is enabled. [[1]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73L622-R629) [[2]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73R639-R670) [[3]](diffhunk://#diff-fb00d6ffa1e2f8db4562a272bd7443766dbe9075d95ea008f37ff262cc790c73R39)

**Testing**
- [`tests/Fixtures/ObjectWithTypedArraySkippingScalars.php`](diffhunk://#diff-b7579bdee30a3ef7495a1cfe632c317dbe36e3acc5d0a9362bd96f9e177d6085R1-R12): Added a new fixture class to test the behavior of the `skipScalars` option.
- [`tests/HydratorTest.php`](diffhunk://#diff-3b8e75171bace0a2d31b0bbcbe08a09259f3c74451d94e3bc3ac297cd2139c45R399-R433): Added tests to verify that arrays with mixed scalar and object values are handled correctly when `skipScalars` is enabled, and that a `TypeError` is thrown when it is not.… and null values during hydration